### PR TITLE
The precedence of ScreenshooterLifecycleObserver should be increased

### DIFF
--- a/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterLifecycleObserver.java
+++ b/arquillian-recorder-screenshooter-base/arquillian-recorder-screenshooter-impl-base/src/main/java/org/arquillian/extension/recorder/screenshooter/impl/ScreenshooterLifecycleObserver.java
@@ -93,7 +93,7 @@ public class ScreenshooterLifecycleObserver {
         }
     }
 
-    public void afterTest(@Observes AfterTestLifecycleEvent event, TestResult result) {
+    public void afterTest(@Observes(precedence = 50) AfterTestLifecycleEvent event, TestResult result) {
         if (new TakingScreenshotDecider(recorderStrategyRegister.get()).decide(event, result)) {
             ScreenshotMetaData metaData = getMetaData(event);
             metaData.setTestResult(result);


### PR DESCRIPTION
Some people does cleanup after executing a test case which can lead into a blank page or similar, increasing the observer should prevent it.

Precedence value not checked.
